### PR TITLE
Build 01

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,42 +1,13 @@
-
-# nmake makefile
-# share must be linked as COM file
-# best is to use TC 2.01 which is freely available
-
-USETC2=1
-COM=1
-
-!if $(USETC2)
-CCBASE=c:\tc201
-BINBASE=
-!else
-CCBASE=c:\tc30
-BINBASE=\bin
-!endif
-
-!if $(COM)
-COPT=-c -mt -1 -I$(INCLUDE)
-LOPT=/m /s /c /t
-!else
-COPT=-c -ms -1 -I$(INCLUDE)
-LOPT=/m /s /c
-!endif
-
-CC=$(CCBASE)$(BINBASE)\tcc
-LD=$(CCBASE)$(BINBASE)\tlink
-LIBS=$(CCBASE)\lib
-INCLUDE=$(CCBASE)\include
-
 share.com: share.obj
-	$(TLINK) $(LOPT) $(LIBS)\c0t.obj share.obj,share.com,,$(LIBS)\cs.lib
+	$(LD) $(LOPT)
 
 share.obj: share.c
-	$(TCC) $(COPT) share.c
+	$(CC) $(COPT)
 
 clean:
-	del *.obj
+	$(RM) *.obj
 	
 clobber: clean
-	del *.com
-	del *.exe
-	del *.map
+	$(RM) *.com
+	$(RM) *.exe
+	$(RM) *.map

--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,15 @@
-share.com: share.obj
+share.com: share.obj $(XOBJS)
 	$(LD) $(LOPT)
 
 share.obj: share.c
 	$(CC) $(COPT)
 
+gcc_help.obj: gcc_help.asm
+	nasm -f elf $< -o $@
+
 clean:
 	$(RM) *.obj
-	
+
 clobber: clean
 	$(RM) *.com
 	$(RM) *.exe

--- a/Makefile
+++ b/Makefile
@@ -27,16 +27,16 @@ LD=$(CCBASE)$(BINBASE)\tlink
 LIBS=$(CCBASE)\lib
 INCLUDE=$(CCBASE)\include
 
-SHARE.COM: SHARE.OBJ
-	$(LD) $(LOPT) $(LIBS)\c0t.obj share.obj,share.com,,$(LIBS)\cs.lib
+share.com: share.obj
+	$(TLINK) $(LOPT) $(LIBS)\c0t.obj share.obj,share.com,,$(LIBS)\cs.lib
 
-SHARE.OBJ: SHARE.C    
-	$(CC) $(COPT) share.c
+share.obj: share.c
+	$(TCC) $(COPT) share.c
 
-CLEAN:
+clean:
 	del *.obj
 	
-CLOBBER: CLEAN
+clobber: clean
 	del *.com
 	del *.exe
 	del *.map

--- a/build.bat
+++ b/build.bat
@@ -1,0 +1,31 @@
+rem Call this batch file with an argument of tcc3 or tcc2 to select compiler
+goto %1
+
+:tcc2
+rem ############# Turbo C 2.01 ########################
+set PATH=C:\bin;C:\tc201;%PATH%
+set LIBS=C:\tc201\lib
+set CC=tcc
+set LD=tlink
+rem Small
+rem set COPT=-c -ms -1 share.c
+rem set LOPT=/m /s /c $(LIBS)\c0s.obj share.obj,share.com,,$(LIBS)\cs.lib
+rem Tiny
+set COPT=-c -mt -1 share.c
+set LOPT=/m /s /c /t $(LIBS)\c0t.obj share.obj,share.com,,$(LIBS)\cs.lib
+goto doit
+
+:tcc3
+rem ############# TURBO_C 3 ########################
+set PATH=C:\bin;C:\tc\bin;%PATH%
+set LIBS=C:\tc\lib
+set CC=tcc
+set LD=tlink
+rem Tiny
+set COPT=-c -mt -1 share.c
+set LOPT=/m /s /c /t -L$(LIBS) c0t.obj share.obj,share.com,,cs.lib
+goto doit
+
+:doit
+rem We use GNU make for all targets
+make

--- a/build.sh
+++ b/build.sh
@@ -6,7 +6,14 @@ if [ x"${COMPILER}" = "xgcc" ] ; then
   export LOPT="-li86"
 
 elif [ x"${COMPILER}" = "xtcc2-emu" ] ; then
+  if ! $(file "share.c" | grep -q CRLF) ; then
+    echo "Warning: Turbo C 2.01 doesn't process files with Unix line endings"
+    echo "         Converting ..."
+    unix2dos "share.c"
+    UNDO=1
+  fi
   dosemu -q -td -K . -E "build.bat tcc2"
+  [ "$UNDO" = "1" ] && dos2unix "share.c"
   exit $?
 
 elif [ x"${COMPILER}" = "xtcc3-emu" ] ; then

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+
+if [ x"${COMPILER}" = "xgcc" ] ; then
+  export CC="ia16-elf-gcc"
+  export COPT="-Wall -fpack-struct -mcmodel=tiny -o "
+  export LOPT="-li86"
+
+elif [ x"${COMPILER}" = "xtcc2-emu" ] ; then
+  dosemu -q -td -K . -E "build.bat tcc2"
+  exit $?
+
+elif [ x"${COMPILER}" = "xtcc3-emu" ] ; then
+  dosemu -q -td -K . -E "build.bat tcc3"
+  exit $?
+
+else
+  echo "Please set the COMPILER env var to one of"
+  echo "Cross compile           : 'gcc' (not working yet)"
+  echo "Native compile (Dosemu) : 'tcc2-emu' or 'tcc3-emu'"
+  exit 1
+fi
+
+make

--- a/build.sh
+++ b/build.sh
@@ -2,8 +2,11 @@
 
 if [ x"${COMPILER}" = "xgcc" ] ; then
   export CC="ia16-elf-gcc"
-  export COPT="-Wall -fpack-struct -mcmodel=tiny -o "
-  export LOPT="-li86"
+  export COPT="-Wall -fpack-struct -mcmodel=tiny -c share.c -o share.obj -Os"
+  export XOBJS="gcc_help.obj"
+  export LD="ia16-elf-ld"
+  export LOPT="share.obj ${XOBJS} -o share.com -li86 --script gcc_help.ld -Map=share.map"
+  make
 
 elif [ x"${COMPILER}" = "xtcc2-emu" ] ; then
   if ! $(file "share.c" | grep -q CRLF) ; then
@@ -22,9 +25,7 @@ elif [ x"${COMPILER}" = "xtcc3-emu" ] ; then
 
 else
   echo "Please set the COMPILER env var to one of"
-  echo "Cross compile           : 'gcc' (not working yet)"
+  echo "Cross compile           : 'gcc'"
   echo "Native compile (Dosemu) : 'tcc2-emu' or 'tcc3-emu'"
   exit 1
 fi
-
-make

--- a/gcc_help.asm
+++ b/gcc_help.asm
@@ -63,11 +63,22 @@ old_sp:
 
 section .text
 
-extern old_handler2f
 extern inner_handler
 
 global handler2f
 handler2f:
+	; IBM Interrupt Sharing Protocol header
+	jmp istart
+global old_handler2f
+old_handler2f: dd 0
+	dw 0x424b	; ("KB")
+	db 0		; flag
+	jmp .hwreset
+	times 7 db 0	; pad 7 bytes
+.hwreset:
+	iret
+
+istart:
 	; save the input DS
 	mov  [CS:iregs.ds], DS
 

--- a/gcc_help.asm
+++ b/gcc_help.asm
@@ -1,0 +1,130 @@
+bits 16
+
+cpu 8086
+
+section .tsr_text
+
+extern __lnon_resident_text
+extern __edata
+extern __snon_resident_text
+extern _start
+
+global tsr_startup
+tsr_startup:
+	pushf
+	push SI
+	push DI
+	push CX
+
+	; copy text out from .bss
+	mov CX, __lnon_resident_text
+	mov SI, __edata
+	mov DI, __snon_resident_text
+	cld
+	rep movsb
+
+	pop CX
+	pop DI
+	pop SI
+	popf
+
+	; jump to standard startup code
+	jmp _start
+
+section .bss
+
+global iregs
+iregs:
+	.bp: resw 1
+	.di: resw 1
+	.si: resw 1
+	.ds: resw 1
+	.es: resw 1
+	.dx: resw 1
+	.cx: resw 1
+	.bx: resw 1
+	.ax: resw 1
+	.ip: resw 1
+	.cs: resw 1
+	.flags: resw 1
+
+global need_to_chain
+need_to_chain:
+	resw 1
+
+global top_of_stack
+top_of_stack:
+	resw 1
+
+old_ss:
+	resw 1
+old_sp:
+	resw 1
+
+section .text
+
+extern old_handler2f
+extern inner_handler
+
+global handler2f
+handler2f:
+	; save the input DS
+	mov  [CS:iregs.ds], DS
+
+	; set our data segment
+	push CS
+	pop DS
+
+	; save regs
+	mov  [iregs.bp], BP
+	mov  [iregs.di], DI
+	mov  [iregs.si], SI
+	mov  [iregs.es], ES
+	mov  [iregs.dx], DX
+	mov  [iregs.cx], CX
+	mov  [iregs.bx], BX
+	mov  [iregs.ax], AX
+	; don't need IP or CS
+	pushf
+	pop word [iregs.flags]
+
+	; setup stack
+	mov [old_ss], SS
+	mov [old_sp], SP
+	push CS
+	pop SS
+	mov SP, [top_of_stack]
+
+	; call our handler
+	call inner_handler
+
+	; restore stack
+	mov SS, [old_ss]
+	mov SP, [old_sp]
+
+	; restore register input values
+	mov  BP, [iregs.bp]
+	mov  DI, [iregs.di]
+	mov  SI, [iregs.si]
+	mov  ES, [iregs.es]
+	mov  DX, [iregs.dx]
+	mov  CX, [iregs.cx]
+	mov  BX, [iregs.bx]
+	mov  AX, [iregs.ax]
+
+	push word [iregs.flags]
+	popf
+
+	; restore caller's DS
+	mov  DS, [iregs.ds]
+
+	; return from interrupt if we handled it
+	cmp  word [CS:need_to_chain], 0
+	jnz  .run_old
+	iret
+
+.run_old:
+	; jump to old handler that will iret
+	push word [CS:old_handler2f + 2]
+	push word [CS:old_handler2f]
+	retf

--- a/gcc_help.ld
+++ b/gcc_help.ld
@@ -1,0 +1,89 @@
+/*
+ * Linker script for DOS TSR executables with combined data and text segment.
+ */
+
+OUTPUT_FORMAT(binary)
+ENTRY(_start)
+INPUT(-l:crtbegin.o -l:crtend.o -l:dos-t-c0.o)
+GROUP(-lc -lgcc -ldos-t -lm)
+
+SEARCH_DIR("/usr/ia16-elf/lib");
+SEARCH_DIR("/usr/lib/x86_64-linux-gnu/gcc/ia16-elf/6.3.0");
+
+/* Currently shows a problem with _exit() ending up in non resident text
+   NOCROSSREFS_TO(".non_resident_text", ".text")
+ */
+
+SECTIONS
+  {
+    . = SEGMENT_START ("text-segment", 0x100);
+    /* Target text sections.  */
+    .text : {
+		__stext = .;
+	/* copy __lnon_resident_text bytes from __edata to __snon_resident_text */
+		*(.tsr_text) *(.tsr_text.*)
+
+	/* program resident text */
+		*(.text) *(.text.*)
+		__etext = .;
+	}
+	__ltext = __etext - __stext;
+
+    /* Target data sections.  */
+    .data : {
+		__sdata = .;
+
+		/* Build lists of constructors and destructors.  */
+		KEEP (*crtbegin*.o(.ctors))
+		KEEP (*(EXCLUDE_FILE (*crtend*.o ) .ctors))
+		KEEP (*(SORT(.ctors.*)))
+		KEEP (*(.ctors))
+
+		KEEP (*crtbegin*.o(.dtors))
+		KEEP (*(EXCLUDE_FILE (*crtend*.o ) .dtors))
+		KEEP (*(SORT(.dtors.*)))
+		KEEP (*(.dtors))
+
+		*(.rodata) *(.rodata.*)
+		*(.data) *(.data.*)
+		*(.gcc_except_table)
+		__edata = .;
+	}
+
+    .bss (NOLOAD) : {
+		 __sbss = .;
+                *(.bss) *(.bss.*)
+                *(COMMON)
+                __ebss = .;
+
+                /* Minimum address allowed for sbrk() to use.  */
+                __heap_end_minimum = ALIGN(8);
+	}
+
+	__ldata = __edata - __sdata;
+	__lbss0 = __ebss - __sbss;
+	__lbss1 = __lbss0 + 1;
+	__lbss = __lbss1 / 2;
+
+    .non_resident_text 0xf000 - __lnon_resident_text : AT (__edata) {
+		__snon_resident_text = .;
+		*(.startupA)
+		*(.msdos_init) *(.msdos_init.*)
+		*(.startupB)
+		*(.init)
+		*(.startupC)
+		*(.fini)
+		*(.startupD)
+		*(.non_resident_text) *(.non_resident_text.*)
+		__enon_resident_text = .;
+	}
+	__lnon_resident_text = __enon_resident_text - __snon_resident_text;
+
+    ASSERT(. <= 0xfd00, "Error: too large for a .com file.")
+
+    /* Used by the memory resizing and DPMI initialization code in
+       dos-models-crt0.S.  */
+    __msdos_initial_alloc_paras = 0x1000;
+
+    /DISCARD/ : { *(.*) }
+  }

--- a/share.c
+++ b/share.c
@@ -245,7 +245,8 @@ static void interrupt far handler2f(intregs_t iregs) {
 	/* nasm -fobj -o foo.obj foo.asm ... */
 
 #elif defined(__GNUC__)
-void __far __interrupt (*old_handler2f)(void) = NULL;
+/* Within IBM Interrupt Sharing Protocol header */
+extern void __far __interrupt (*old_handler2f)(void);
 
 /* Prototype for NASM wrapper function */
 extern void __far __interrupt __attribute__((near_section)) handler2f(void);


### PR DESCRIPTION
This PR aims to:
  - Make the build process more OS agnostic.
  - Add a second functional compiler choice (GCC ia16 cross compiler)
  - Reduce memory consumption on GCC by means of creative linking
  - Adds IBM Interrupt Sharing Protocol header to resident code for better interoperability with debuggers and other TSR that want to hook int2f

Type|Turbo C 2.01|Gcc ia16
------|----------|-----------
File size (bytes) | 6300 | 5336
Resident size (paragraphs)| 0x0240 | 0x01bb

Tested GCC using Dosemu2 test 'test_fat_ds3_share_open_twice' and shows identical results to TCC 2.01