### PR TITLE
Interface: Add subfunction is_file_open() to the multiplex

### DIFF
--- a/share.c
+++ b/share.c
@@ -219,6 +219,8 @@ static int lock_unlock
 	 unsigned long len,	/* length (in bytes) of region to lock or unlock */
 	 int unlock);		/* non-zero to unlock; zero to lock */
 
+static int is_file_open(char far *filename);
+
 	/* Multiplex interrupt handler */
 
 #if defined(__TURBOC__)
@@ -320,6 +322,12 @@ void inner_handler(void) {
 				 (   (((unsigned long)iregs.es)<<16) | ((unsigned long)iregs.dx)   ),
 #endif
 				 (iregs.ax & 0x01));
+			return;
+		}
+
+			/* is_file_open (0xa6)*/
+		if ((iregs.ax & 0xff) == 0xa6) {
+			iregs.ax = is_file_open(MK_FP(iregs.ds, iregs.si));
 			return;
 		}
 	}
@@ -614,6 +622,17 @@ static int lock_unlock
 		}
 		return -(0x24);		/* sharing buffer overflow */
 	}
+}
+
+static int is_file_open(char far *filename)
+{
+	int i;
+
+	for (i = 0; i < file_table_size; i++) {
+		if (fnmatches(filename, file_table[i].filename))
+			return 1;
+	}
+	return 0;
 }
 
 		/* ------------- INIT ------------- */


### PR DESCRIPTION
In order that the FreeDOS kernel can determine if it's acceptable
to delete or rename a file it must first know whether a file is
open. This patch creates a new subfunction int2f/0x10a6 that the
kernel may use for this purpose. A similar patch, with identical
subfunction numbering, has been applied to FDPP see
https://github.com/dosemu2/fdpp/commit/691721f1.

A patch that makes use of this is coming for the FreeDOS kernel