### PR TITLE
Function 22h getctrl2

### DIFF
--- a/gcc_help.asm
+++ b/gcc_help.asm
@@ -339,8 +339,10 @@ asm_get_status:
 	add di, ssFileSize
 	mov ds, dx
 	mov si, bx
-	mov cx, 4
-	rep movsw
+	movsw
+	movsw
+	movsw
+	movsw
 	jmp @FF
 
 @@:

--- a/gcc_help.asm
+++ b/gcc_help.asm
@@ -105,11 +105,14 @@ OUT:	al = size of returned data (not 0 if supported, 3 for now)
 
 SHARE - Get data on free and total structures
 INP:	al = 22h
-OUT:	al = FFh if supported
-	bx = file table total size (amount entries)
-	cx = file table free amount entries
-	si = lock table total size (amount entries)
-	di = lock table free amount entries
+OUT:	al = FFh if supported without table,
+	 bx = file table total size (amount entries)
+	 cx = file table free amount entries
+	 si = lock table total size (amount entries)
+	 di = lock table free amount entries
+	al = 8 if supported with table,
+	 dx:bx -> table of 4 words,
+	 file total, file free, lock total, lock free
 
 TSR - Reserved for TSR
 INP:	al = 23h..FFh
@@ -135,6 +138,8 @@ amisintr:
 	dw i2D
 
 
+	; These variables are used as globals
+	;  by the C code. Each is an uint16_t.
 global file_table_size
 global file_table_free
 global lock_table_size

--- a/gcc_help.asm
+++ b/gcc_help.asm
@@ -338,7 +338,6 @@ asm_get_status:
 	int 2Dh
 	cmp al, 8
 	jne @F
-	pop di
 	push ds
 	pop es
 	add di, ssFileSize
@@ -348,6 +347,7 @@ asm_get_status:
 	movsw
 	movsw
 	movsw
+	pop di
 	jmp @FF
 
 @@:

--- a/share.c
+++ b/share.c
@@ -156,11 +156,11 @@ typedef struct {
 		/* ------------- GLOBALS ------------- */
 static char progname[9] NON_RES_BSS;
 static unsigned int file_table_size_bytes NON_RES_DATA = 2048;
-unsigned int file_table_size = 0;	/* # of file_t we can have */
-unsigned int file_table_free = 0;
+extern uint16_t file_table_size;	/* # of file_t we can have */
+extern uint16_t file_table_free;
 static file_t *file_table = NULL;
-unsigned int lock_table_size = 20;	/* # of lock_t we can have */
-unsigned int lock_table_free = 20;
+extern uint16_t lock_table_size;	/* # of lock_t we can have */
+extern uint16_t lock_table_free;
 static lock_t *lock_table = NULL;
 
 


### PR DESCRIPTION
This changes the globals that count total and free file and lock table entries to be defined in the assembly source. This allows to return a pointer to them in AMIS function 22h, instead of their contents. This saves a bit of resident space. The `asm_get_status` works with either a return of `al` = 8 or `al` = FFh and uses that to determine whether the table or register return is used.